### PR TITLE
Association methods

### DIFF
--- a/lib/skroutz/client.rb
+++ b/lib/skroutz/client.rb
@@ -40,8 +40,8 @@ class Skroutz::Client
   end
 
   Skroutz::RESOURCES.each do |resource|
-    define_method resource.pluralize do
-      "Skroutz::#{resource.classify.pluralize}Collection".constantize.new self
+    define_method resource.pluralize do |id = nil|
+      "Skroutz::#{resource.classify.pluralize}Collection".constantize.new id, self
     end
   end
 

--- a/lib/skroutz/collection_proxy.rb
+++ b/lib/skroutz/collection_proxy.rb
@@ -2,9 +2,10 @@ class Skroutz::CollectionProxy
   include Skroutz::Parsing
   include Skroutz::UrlHelpers
 
-  attr_accessor :client, :owner
+  attr_accessor :id, :client, :owner
 
-  def initialize(client, owner = nil)
+  def initialize(id, client, owner = nil)
+    @id = id
     @client = client
     @owner = owner
   end
@@ -44,5 +45,21 @@ class Skroutz::CollectionProxy
 
   def model_name
     @model_name ||= "Skroutz::#{resource.classify}".constantize
+  end
+
+  private
+
+  def method_missing(method, *args, &block)
+    options = args.first || {}
+    url_prefix = options.delete(:url_prefix) || ''
+
+    target_url = "#{base_path}/#{id}/#{method}"
+    target_url.prepend("#{url_prefix}/") if url_prefix
+
+    response = client.get(target_url, options)
+
+    return parse(response) unless block_given?
+
+    yield response
   end
 end

--- a/lib/skroutz/collection_proxy.rb
+++ b/lib/skroutz/collection_proxy.rb
@@ -52,11 +52,12 @@ class Skroutz::CollectionProxy
   def method_missing(method, *args, &block)
     options = args.first || {}
     url_prefix = options.delete(:url_prefix) || ''
+    verb = options.delete(:verb) || options.delete(:via) || :get
 
     target_url = "#{base_path}/#{id}/#{method}"
     target_url.prepend("#{url_prefix}/") if url_prefix
 
-    response = client.get(target_url, options)
+    response = client.send(verb, target_url, options)
 
     return parse(response) unless block_given?
 


### PR DESCRIPTION
Implement direct association methods.

Example:

To fetch the SKUs of a category the following call should return them performing only 1 API request:

```ruby
client.categories(category_id).skus
```