### PR TITLE
Fix broken error handling specs

### DIFF
--- a/spec/support/shared_examples/error_handling.rb
+++ b/spec/support/shared_examples/error_handling.rb
@@ -93,7 +93,7 @@ shared_examples 'an error handled request' do
   end
 
   describe 'response timeout' do
-    let(:response) { request_stub.to_timeout }
+    let(:response) { request_stub.to_raise(Timeout::Error) }
 
     it 'raises Skroutz::TimeoutError' do
       expect { request }.to raise_error(Skroutz::TimeoutError)


### PR DESCRIPTION
The reason the specs are failing is because of the following change
in the webmock gem:
https://github.com/bblimke/webmock/commit/1c48030ec0671e368d5be09f39cdfbed6a87b10f#diff-4fd2506a42939f27882b390651103483

RequestStub:to_timeout method now raises a Net::OpenTimeout exception
instead of a Timeout::Error. The Net::OpenTimeout error when using Faraday
is wrapped in a Faraday::ConnectionFailed error, that is not rescued and re-raised
as a Skroutz::Timeout error: https://github.com/skroutz/skroutz.rb/blob/master/lib/skroutz/errors.rb#L92